### PR TITLE
Ensure that all Spring dependencies are 4.0.0.M2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,16 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-messaging</artifactId>
-      <version>${org.springframework-version}</version>
-    </dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jdbc</artifactId>
+			<version>${org.springframework-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-messaging</artifactId>
+			<version>${org.springframework-version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>


### PR DESCRIPTION
Spring Security brings with it a transitive dependency on spring-jdbc which, in turn, pulls in spring-tx. This was leading to these two modules being version 3.2.3.RELEASE whereas the rest of Spring was version 4.0.0.M2.

An explicit dependency on spring-jdbc has been declared which ensures that all Spring dependencies are the same version (4.0.0.M2)
