### PR TITLE
Adapt to breaking API changes

### DIFF
--- a/src/main/java/org/springframework/samples/portfolio/config/WebConfig.java
+++ b/src/main/java/org/springframework/samples/portfolio/config/WebConfig.java
@@ -92,8 +92,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
 	@Bean
 	@Profile("simple-broker")
 	public SimpleBrokerMessageHandler simpleBrokerMessageHandler() {
-		SimpleBrokerMessageHandler handler = new SimpleBrokerMessageHandler(webSocketHandlerChannel());
-		handler.setDestinationPrefixes(Arrays.asList("/topic/", "/queue/"));
+		SimpleBrokerMessageHandler handler = new SimpleBrokerMessageHandler(webSocketHandlerChannel(), Arrays.asList("/topic/", "/queue/"));
 		dispatchChannel().subscribe(handler);
 		return handler;
 	}


### PR DESCRIPTION
Destinations must now be specified in the SimpleBrokerMessageHandler
constructor.
