### PR TITLE
Upgrade to Reactor 1.0.0.M3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,14 +61,14 @@
 		<dependency>
 			<groupId>org.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
-			<version>1.0.0.M2</version>
+			<version>1.0.0.M3</version>
 		</dependency>
 
 		<!-- Required when the "stomp-broker-relay" profile is enabled -->
 		<dependency>
 			<groupId>org.projectreactor</groupId>
 			<artifactId>reactor-tcp</artifactId>
-			<version>1.0.0.M2</version>
+			<version>1.0.0.M3</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
In M2, Reactor uses a yielding wait strategy for the default RingBuffer.
This led to one CPU core being fully occupied, i.e. CPU usage was 100%,
even when idle. Reactor's M3 changes to using a blocking wait strategy
which removes this unwanted CPU usage (at the cost of increased
latency).
