### PR TITLE
Generate full URL from document one for SockJS client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
 	<version>1.0.0-SNAPSHOT</version>
 
 	<properties>
-		<org.springframework-version>4.0.3.BUILD-SNAPSHOT</org.springframework-version>
-		<org.springframework.security-version>3.2.0.RELEASE</org.springframework.security-version>
+		<org.springframework-version>4.0.3.RELEASE</org.springframework-version>
+		<org.springframework.security-version>3.2.3.RELEASE</org.springframework.security-version>
 	</properties>
 
 	<dependencies>
@@ -138,19 +138,19 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>8.0.1</version>
+            <version>8.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
-            <version>8.0.1</version>
+            <version>8.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-logging-log4j</artifactId>
-            <version>8.0.1</version>
+            <version>8.0.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/webapp/cujojs/main.js
+++ b/src/main/webapp/cujojs/main.js
@@ -16,7 +16,8 @@ define(function (require) {
 
 //	bus.logger({ prefix: 'dead', tap: 'deadLetterChannel' });
 
-	socket = new SockJS('/spring-websocket-portfolio/portfolio');
+	var url = document.URL.replace('cujojs/', '') + 'portfolio';
+	socket = new SockJS(url);
 	socket.addEventListener('open', function () {
 		var bridge, portfolio, trade, app;
 

--- a/src/main/webapp/traditional/index.html
+++ b/src/main/webapp/traditional/index.html
@@ -109,7 +109,8 @@
     <script src="portfolio.js"></script>
     <script type="text/javascript">
       (function() {
-        var socket = new SockJS('/spring-websocket-portfolio/portfolio');
+        var url = document.URL.replace('traditional/', '') + 'portfolio';
+        var socket = new SockJS(url, null, {protocols_whitelist: ['websocket']});
         var stompClient = Stomp.over(socket);
 
         var appModel = new ApplicationModel(stompClient);


### PR DESCRIPTION
This allows this application to work even if deployed to other
context paths (like /) and also enables to use websocket transport
since SockJS needs full url in order to replace http protocol by
ws one.

It also fixes iframe based transports.
