### PR TITLE
fixed integration tests

### DIFF
--- a/src/test/java/org/springframework/samples/portfolio/web/load/StompWebSocketLoadTestServer.java
+++ b/src/test/java/org/springframework/samples/portfolio/web/load/StompWebSocketLoadTestServer.java
@@ -156,7 +156,6 @@ public class StompWebSocketLoadTestServer {
 			return false;
 		}
 
-		@Bean
 		public HomeController homeController() {
 			return new HomeController();
 		}


### PR DESCRIPTION
on my local machine, running from Eclipse was giving this error while try to run IntegrationPortfolioTests,
Caused by: java.lang.IllegalStateException: Ambiguous mapping found. Cannot map 'homeController' bean method 
it seems that @Bean annotation was superfluous
